### PR TITLE
Use Artifact Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ You need create a service accounts has Storage Write and Cloud Pub/Sub Subscribe
 $ make build/image
 
 # <projcet_id> your gcp project id
-$ docker tag pipeflow:latest asia.gcr.io/<project_id>/pipeflow:latest
-$ docker push asia.gcr.io/<project_id>/pipeflow:latest
+$ docker tag pipeflow:latest asia.gcr.io/<project_id>/<repository_name>/pipeflow:latest
+$ docker push asia-docker.pkg.dev/<project_id>/<repository_name>/pipeflow:latest
 ```
 
 5. Deploy to Cloud Run
 ```
 $ gcloud beta run deploy pipeflow \
 		--project <project_id> \
-		--image="asia.gcr.io/<project_id>/pipeflow:latest" \
+		--image="asia-docker.pkg.dev/<project_id>/<repository_name>/pipeflow:latest" \
 		--port=8080 \
 		--region=asia-northeast1 \
 		--platform=managed \

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,9 +2,9 @@
 set -e
 
 read -p "gcp project id: " gcp_project_id
-read -p "cloud run region: " region
+read -p "cloud run region (default: asia-northeast1): " region
 read -p "repository name: " repository_name
-read -p "your repository region: " repo_region
+read -p "your repository region (default: asia): " repo_region
 read -p "cloud pubsub subscription: " pubsub_sub
 read -p "gcs bucket name: " bucket_name
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+read -p "gcp project id: " gcp_project_id
+read -p "cloud run region: " region
+read -p "repository name: " repository_name
+read -p "your repository region: " repo_region
+read -p "cloud pubsub subscription: " pubsub_sub
+read -p "gcs bucket name: " bucket_name
+
+region=${region:-asia-northeast1}
+repo_region=${repo_region:-asia}
+
+gcloud beta run deploy pipeflow \
+  --min-instances 1 \
+		--project $gcp_project_id \
+		--image="$repo_region-docker.pkg.dev/$gcp_project_id/$repository_name/pipeflow:latest" \
+		--port=8080 \
+		--region=$region \
+		--platform=managed \
+		--memory=512Mi \
+		--allow-unauthenticated \
+		--service-account=pipeflow@${gcp_project_id}.iam.gserviceaccount.com \
+		--set-env-vars \
+		GCP_PROJECT_ID=${gcp_project_id},PUBSUB_SUBSCRIPTION=${pubsub_sub},BUCKET_NAME=${bucket_name},BUCKET_PREFIX=pipeflow


### PR DESCRIPTION
ref https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr?hl=ja&_gl=1*hcmo7t*_ga*MjA4MjYwNzk4NS4xNjk1OTU5Mjg0*_ga_WH2QY8WWF5*MTcxNTY1MTg4Ni4yNzcuMS4xNzE1NjUzMzQwLjAuMC4w&_ga=2.199526445.-2082607985.1695959284

I have modified README.md to use Artifact Registry instead because Container Registry is already deprecated and be scheduled to discontinue.

And I had create deploy.sh to generate a pipeflow service on Cloud Run. 